### PR TITLE
Add support for deploy_env varible which must be set for play to correctly target hosts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Repository for holding RabbitMQ configuration
 # Creating a Fully Clustered HA RabbitMQ with Ansible
 
 1. Create 2 EC2 Ubuntu instances (set an appropriate security group and key pair)
-2. Add a Route53 entry for rabbitmq1.eq.ons.digital and rabbitmq2.eq.ons.digital
+2. Add a Route53 entry for test-rabbitmq1.eq.ons.digital and test-rabbitmq2.eq.ons.digital
 3. Point the entries at the above EC2 instances
 4. Log on to each EC2 instance
     a. Modify the host name to either rabbitmq1 or rabbitmq2 making sure to match the correct route 53 entry
@@ -16,16 +16,16 @@ Repository for holding RabbitMQ configuration
         sudo vi /etc/hosts
          e.g.  
          ```
-                172.31.1.113 rabbitmq1.eq.ons.digital rabbitmq1
-                172.31.1.112 rabbitmq2.eq.ons.digital rabbitmq2
+                172.31.1.113 test-rabbitmq1.eq.ons.digital test-rabbitmq1
+                172.31.1.112 test-rabbitmq2.eq.ons.digital test-rabbitmq2
          ```
 5. Install ansible locally using either pip or homebrew (you can add it to the boxen manifest).
 6. Modify your /etc/ansible/hosts file, adding these entries:
 
 ```
 sudo tee /etc/ansible/hosts <<EOF
-rabbitmq1.eq.ons.digital
-rabbitmq2.eq.ons.digital
+test-rabbitmq1.eq.ons.digital
+test-rabbitmq2.eq.ons.digital
 EOF
 
 ```
@@ -40,7 +40,7 @@ sudo ansible-galaxy install warrenbailey.rabbitmq
 setup the HA capability so that queues replicated to each other.
 
 ```
-ansible-playbook --private-key digital-eq-keypair.pem -v ansible/rabbitmq-cluster.yml
+ansible-playbook -i 'test-rabbitmq1.eq.ons.digital,test-rabbitmq2.eq.ons.digital'  --private-key digital-eq-keypair.pem ansible/rabbitmq-cluster.yml --extra-vars "deploy_env=test
 ```
 
 ## How to run post install test

--- a/ansible/rabbitmq-cluster.yml
+++ b/ansible/rabbitmq-cluster.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: rabbitmq1.eq.ons.digital
+- hosts: "{{deploy_env}}-rabbitmq1.eq.ons.digital"
   sudo: yes
   user: ubuntu
   roles:
@@ -8,13 +8,13 @@
 
   vars:
    rabbitmq_create_cluster: yes
-   rabbitmq_cluster_master: rabbitmq1.eq.ons.digital
+   rabbitmq_cluster_master: "{{deploy_env}}-rabbitmq1.eq.ons.digital"
    rabbitmq_use_longname: 'true'
    rabbitmq_ha_enabled: yes
    rabbitmq_ha_mode: all
    rabbitmq_ha_pattern: '.*'
 
-- hosts: rabbitmq2.eq.ons.digital
+- hosts: "{{deploy_env}}-rabbitmq2.eq.ons.digital"
   sudo: yes
   user: ubuntu
   roles:
@@ -22,9 +22,8 @@
 
   vars:
    rabbitmq_use_longname: 'true'
-   rabbitmq_cluster_master: rabbitmq1.eq.ons.digital
+   rabbitmq_cluster_master: "{{deploy_env}}-rabbitmq1.eq.ons.digital"
    rabbitmq_create_cluster: yes
    rabbitmq_ha_enabled: yes
    rabbitmq_ha_mode: all
    rabbitmq_ha_pattern: '.*'
-


### PR DESCRIPTION
**What**
Adding the deploy env to the ansible playbook.

**How to test**
1. Follow the steps in the README to deploy two ec2 instances

Run the command:
`ansible-playbook -i 'test-rabbitmq1.eq.ons.digital,test-rabbitmq2.eq.ons.digital'  --private-key pre-prod.pem ansible/rabbitmq-cluster.yml --extra-vars "deploy_env=test"`

Modifying the string to match your deployed environment.

**Who can review**
Anyone apart from @dhilton and @warrenbailey
