### PR TITLE
Adds support for RabbitMQ Management Console to each node

### DIFF
--- a/ansible/rabbitmq-cluster.yml
+++ b/ansible/rabbitmq-cluster.yml
@@ -14,6 +14,9 @@
    rabbitmq_ha_mode: all
    rabbitmq_ha_pattern: '.*'
 
+  tasks:
+   - rabbitmq_plugin: names=rabbitmq_management state=enabled
+
 - hosts: "{{deploy_env}}-rabbitmq2.eq.ons.digital"
   sudo: yes
   user: ubuntu
@@ -27,3 +30,6 @@
    rabbitmq_ha_enabled: yes
    rabbitmq_ha_mode: all
    rabbitmq_ha_pattern: '.*'
+
+  tasks:
+   - rabbitmq_plugin: names=rabbitmq_management state=enabled


### PR DESCRIPTION
**_What**_

Like it says on the tin, adds support for the RabbitMQ Management Console to each node on port 15672

**_How to test**_
1) Run the playbook and visit each node in turn on port 15672 in the browser, you should see the login page

**_Who can test**_

Anybody but @weapdiv-david
