### PR TITLE
Remove default users and create admin, write and read users

### DIFF
--- a/ansible/rabbitmq-cluster.yml
+++ b/ansible/rabbitmq-cluster.yml
@@ -17,6 +17,43 @@
   tasks:
    - rabbitmq_plugin: names=rabbitmq_management state=enabled
 
+   # remove the default 'guest' user who has administrator access
+   - rabbitmq_user: user=guest
+                    state=absent
+
+   # Create a user who can write to the queues
+   - rabbitmq_user: user={{rabbitmq_write_user}}
+                    password={{rabbitmq_write_password}}
+                    force=yes
+                    vhost=/
+                    write_priv=.*
+                    configure_priv=.*
+                    read_priv=.*
+                    state=present
+
+   # Create a user who can read from queues
+   - rabbitmq_user: user={{rabbitmq_read_user}}
+                    password={{rabbitmq_read_password}}
+                    force=yes
+                    vhost=/
+                    read_priv=.*
+                    write_priv=.*
+                    configure_priv=.*
+                    state=present
+
+
+   # Create an admin user
+   - rabbitmq_user: user={{rabbitmq_admin_user}}
+                    password={{rabbitmq_admin_password}}
+                    force=yes
+                    vhost=/
+                    configure_priv=.*
+                    read_priv=.*
+                    write_priv=.*
+                    state=present
+                    tags=administrator
+
+
 - hosts: "{{deploy_env}}-rabbitmq2.eq.ons.digital"
   sudo: yes
   user: ubuntu
@@ -33,3 +70,38 @@
 
   tasks:
    - rabbitmq_plugin: names=rabbitmq_management state=enabled
+
+   # remove the default 'guest' user who has administrator access
+   - rabbitmq_user: user=guest
+                    state=absent
+
+   # Create a user who can write to the queues
+   - rabbitmq_user: user={{rabbitmq_write_user}}
+                    password={{rabbitmq_write_password}}
+                    force=yes
+                    vhost=/
+                    write_priv=.*
+                    configure_priv=.*
+                    read_priv=.*
+                    state=present
+
+   # Create a user who can read from queues
+   - rabbitmq_user: user={{rabbitmq_read_user}}
+                    password={{rabbitmq_read_password}}
+                    force=yes
+                    vhost=/
+                    read_priv=.*
+                    write_priv=.*
+                    configure_priv=.*
+                    state=present
+
+   # Create an admin user
+   - rabbitmq_user: user={{rabbitmq_admin_user}}
+                    password={{rabbitmq_admin_password}}
+                    force=yes
+                    vhost=/
+                    configure_priv=.*
+                    read_priv=.*
+                    write_priv=.*
+                    state=present
+                    tags=administrator


### PR DESCRIPTION
**_What**_

This branch updates the ansible config for rabbitmq to remove the default user accounts and create three new ones.  The three acounts are for the admin, "read-only", and "write-only" users, although currently there are no permissions to limit access on any account.  The admin account is the only one with administrator functionality however.

It requires 6 (yes SIX!) new variables in eq-terraform (also modified) to set up the three accounts.

These are:
- `rabbitmq_admin_user` The new admin username
- `rabbitmq_admin_password` The new admin user password
- `rabbitmq_read_user` The new "read-only" account username
- `rabbitmq_read_password` The new "read-only" account password
- `rabbitmq_write_user` The new "write-only" account username
- `rabbitmq_write_password` The new "write-only" account password

**_How to test**_

1) Check out the branch
2) Set up some environment variables...

```
export MQ_A_USER=admin
export MQ_A_PASS=admin
export MQ_R_USER=read
export MQ_R_PASS=read
export MQ_W_USER=write
export MQ_W_PASS=write
export ENV_NAME=<name of your environment>
```

3) Run the following command

```
ansible-playbook -i "$ENV_NAME-rabbitmq1.eq.ons.digital,$ENV_NAME-rabbitmq2.eq.ons.digital"  --private-key ~/.ssh/pre-prod.pem ../eq-messaging/ansible/rabbitmq-cluster.yml --extra-vars "{\"deploy_env\":\"$ENV_NAME\",\"rabbitmq_admin_user\":\"$MQ_A_USER\",\"rabbitmq_admin_password\":\"$MQ_A_PASS\",\"rabbitmq_write_user\":\"$MQ_W_USER\",\"rabbitmq_write_password\":\"$MQ_W_PASS\",\"rabbitmq_read_user\":\"$MQ_R_USER\",\"rabbitmq_read_password\":\"$MQ_R_PASS\"}"
```

4) SSH into one of your RabbitMQ instances and run:

```
sudo rabbitmqctl list_users
```

5) Verify that your users have been created.

**_Who can test**_

Anybody except @weapdiv-david
