### PR TITLE
Configurable DNS name

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sudo ansible-galaxy install warrenbailey.rabbitmq
 setup the HA capability so that queues replicated to each other.
 
 ```
-ansible-playbook -i 'test-rabbitmq1.eq.ons.digital,test-rabbitmq2.eq.ons.digital'  --private-key digital-eq-keypair.pem ansible/rabbitmq-cluster.yml --extra-vars "deploy_env=test
+ansible-playbook -i 'test-rabbitmq1.eq.ons.digital,test-rabbitmq2.eq.ons.digital'  --private-key digital-eq-keypair.pem ansible/rabbitmq-cluster.yml --extra-vars "deploy_env=test, deploy_dns=eq.ons.digital"
 ```
 
 ## How to run post install test

--- a/ansible/rabbitmq-cluster.yml
+++ b/ansible/rabbitmq-cluster.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: "{{deploy_env}}-rabbitmq1.eq.ons.digital"
+- hosts: "{{deploy_env}}-rabbitmq1.{{deploy_dns}}"
   sudo: yes
   user: ubuntu
   roles:
@@ -8,7 +8,7 @@
 
   vars:
    rabbitmq_create_cluster: yes
-   rabbitmq_cluster_master: "{{deploy_env}}-rabbitmq1.eq.ons.digital"
+   rabbitmq_cluster_master: "{{deploy_env}}-rabbitmq1.{{deploy_dns}}"
    rabbitmq_use_longname: 'true'
    rabbitmq_ha_enabled: yes
    rabbitmq_ha_mode: all
@@ -54,7 +54,7 @@
                     tags=administrator
 
 
-- hosts: "{{deploy_env}}-rabbitmq2.eq.ons.digital"
+- hosts: "{{deploy_env}}-rabbitmq2.{{deploy_dns}}"
   sudo: yes
   user: ubuntu
   roles:
@@ -62,7 +62,7 @@
 
   vars:
    rabbitmq_use_longname: 'true'
-   rabbitmq_cluster_master: "{{deploy_env}}-rabbitmq1.eq.ons.digital"
+   rabbitmq_cluster_master: "{{deploy_env}}-rabbitmq1.{{deploy_dns}}"
    rabbitmq_create_cluster: yes
    rabbitmq_ha_enabled: yes
    rabbitmq_ha_mode: all


### PR DESCRIPTION
**What**
The DNS zone name needs to be configurable as production has a different DNS name

**How to test**
1. Run via terraform using https://github.com/ONSdigital/eq-terraform/pull/11
2. The eq-messaging branch needs to be changed to `production-fix` by adding this command to the ansible resource in message_queue.tf

```
provisioner "local-exec" {
      command = "git clone https://github.com/ONSdigital/eq-messaging.git --branch production-fix tmp/eq-messaging"
    }
```

**Who can review**
Anyone apart from @warrenbailey
