### PR TITLE
Fix adding security updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -58,3 +58,20 @@ python receive.py
 ```
 
 This will then print out to stdout, "[x] Received X", where X will be the message from the queue.
+
+## Testing with Vagrant
+
+This repo includes a Vagrant file that brings up a single Ubuntu Trusty machine (14.0.4LTS) to test the ansible scripts against.
+
+To install Vagrant on a mac:
+```
+brew cask install virtualbox
+brew cask install vagrant
+```
+And then to install the Ansible dependencies:
+```
+sudo ansible-galaxy install jnv.unattended-upgrades
+
+```
+
+You can then issue `vagrant up` which will create a new VM, provision it with the role.yml and allow you to ssh into the machine to check the state has been correctly set. This gives a useful target for testing and developing without having to recreate an entire infrastructure environment.

--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.define "ubuntu" do |ubuntu|
+    ubuntu.vm.box = "ubuntu/trusty64"
+  end
+
+  config.vm.provision :shell, inline: "sudo apt-get install -y python python-apt aptitude"
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "role.yml"
+    ansible.verbose = "vv"
+    ansible.sudo = true
+  end
+end

--- a/ansible/rabbitmq-cluster.yml
+++ b/ansible/rabbitmq-cluster.yml
@@ -5,6 +5,9 @@
   user: ubuntu
   roles:
     - warrenbailey.rabbitmq
+    - role: jnv.unattended-upgrades
+      unattended_origins_patterns:
+      - 'origin=Ubuntu,archive=${distro_codename}-security'
 
   vars:
    rabbitmq_create_cluster: yes
@@ -59,6 +62,9 @@
   user: ubuntu
   roles:
     - warrenbailey.rabbitmq
+    - role: jnv.unattended-upgrades
+      unattended_origins_patterns:
+      - 'origin=Ubuntu,archive=${distro_codename}-security'
 
   vars:
    rabbitmq_use_longname: 'true'

--- a/ansible/role.yml
+++ b/ansible/role.yml
@@ -1,0 +1,9 @@
+---
+
+- hosts: all
+  user: ubuntu
+  roles:
+    - warrenbailey.rabbitmq
+    - role: jnv.unattended-upgrades
+      unattended_origins_patterns:
+      - 'origin=Ubuntu,archive=${distro_codename}-security'


### PR DESCRIPTION
**What**

This PR adds automatic security updates to our RabbitMQ machines, ensuring that they always apply security patches.

**Installation**

brew cask install virtualbox
brew cask install vagrant
sudo ansible-galaxy install jnv.unattended-upgrades

**How to test**
1. Use the vagrant file to create an Ubuntu machine `vagrant up`
2. Once the box has finished provisioning, ssh into the machine `vagrant ssh`
3. Check that the machine has no security updates to apply by issuing the following:

```
sudo su
apt-get -s dist-upgrade |grep "^Inst" |grep -i securi 
apt-get -s dist-upgrade |grep "^Inst" 
```

The first command should return no results, showing no security patches, the second should show other updates that are feature or version upgrades.

**Who can test**

Anyone but @dhilton
