### PR TITLE
EQ-386 Cloudwatch Monitoring for Rabbit MQ Clusters

### DIFF
--- a/ansible/rabbitmq-cluster.yml
+++ b/ansible/rabbitmq-cluster.yml
@@ -20,44 +20,9 @@
    rabbitmq_ha_pattern: '.*'
 
   tasks:
-   - rabbitmq_plugin: names=rabbitmq_management state=enabled
+   - include: tasks/rabbitmq.yml
 
-   # remove the default 'guest' user who has administrator access
-   - rabbitmq_user: user=guest
-                    state=absent
-
-   # Create a user who can write to the queues
-   - rabbitmq_user: user={{rabbitmq_write_user}}
-                    password={{rabbitmq_write_password}}
-                    force=yes
-                    vhost=/
-                    write_priv=.*
-                    configure_priv=.*
-                    read_priv=.*
-                    state=present
-
-   # Create a user who can read from queues
-   - rabbitmq_user: user={{rabbitmq_read_user}}
-                    password={{rabbitmq_read_password}}
-                    force=yes
-                    vhost=/
-                    read_priv=.*
-                    write_priv=.*
-                    configure_priv=.*
-                    state=present
-
-
-   # Create an admin user
-   - rabbitmq_user: user={{rabbitmq_admin_user}}
-                    password={{rabbitmq_admin_password}}
-                    force=yes
-                    vhost=/
-                    configure_priv=.*
-                    read_priv=.*
-                    write_priv=.*
-                    state=present
-                    tags=administrator
-
+   - include: tasks/cloudwatch.yml host={{deploy_env}}-rabbitmq1
 
 - hosts: "{{deploy_env}}-rabbitmq2.{{deploy_dns}}"
   sudo: yes
@@ -78,39 +43,6 @@
    rabbitmq_ha_pattern: '.*'
 
   tasks:
-   - rabbitmq_plugin: names=rabbitmq_management state=enabled
+   - include: tasks/rabbitmq.yml
 
-   # remove the default 'guest' user who has administrator access
-   - rabbitmq_user: user=guest
-                    state=absent
-
-   # Create a user who can write to the queues
-   - rabbitmq_user: user={{rabbitmq_write_user}}
-                    password={{rabbitmq_write_password}}
-                    force=yes
-                    vhost=/
-                    write_priv=.*
-                    configure_priv=.*
-                    read_priv=.*
-                    state=present
-
-   # Create a user who can read from queues
-   - rabbitmq_user: user={{rabbitmq_read_user}}
-                    password={{rabbitmq_read_password}}
-                    force=yes
-                    vhost=/
-                    read_priv=.*
-                    write_priv=.*
-                    configure_priv=.*
-                    state=present
-
-   # Create an admin user
-   - rabbitmq_user: user={{rabbitmq_admin_user}}
-                    password={{rabbitmq_admin_password}}
-                    force=yes
-                    vhost=/
-                    configure_priv=.*
-                    read_priv=.*
-                    write_priv=.*
-                    state=present
-                    tags=administrator
+   - include: tasks/cloudwatch.yml host={{deploy_env}}-rabbitmq2

--- a/ansible/tasks/cloudwatch.yml
+++ b/ansible/tasks/cloudwatch.yml
@@ -1,0 +1,7 @@
+---
+ - apt: name=awscli update_cache=yes
+ - copy: src=tasks/cluster_status.sh dest=/opt/cluster_status.sh owner=ubuntu group=ubuntu mode=0754
+ - lineinfile: dest=/etc/environment line="METRIC_NAME={{host}}"
+ - lineinfile: dest=/etc/environment line="NAMESPACE=RabbitMQClusterStatus"
+ - lineinfile: dest=/etc/environment line="REGION={{region}}"
+ - cron: name="Rabbit MQ Cluster check" minute="*/5" job="/opt/cluster_status.sh"

--- a/ansible/tasks/cluster_status.sh
+++ b/ansible/tasks/cluster_status.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+clusterOK=$(sudo rabbitmqctl cluster_status | grep "{partitions,\[\]}" | wc -l)
+
+
+if [ "$clusterOK" -eq "0" ]; then
+    aws cloudwatch put-metric-data --metric-name $METRIC_NAME --namespace $NAMESPACE --value 1 --region $REGION
+else
+    aws cloudwatch put-metric-data --metric-name $METRIC_NAME --namespace $NAMESPACE --value 0 --region $REGION
+fi

--- a/ansible/tasks/rabbitmq.yml
+++ b/ansible/tasks/rabbitmq.yml
@@ -1,0 +1,38 @@
+---
+   - rabbitmq_plugin: names=rabbitmq_management state=enabled
+
+   # remove the default 'guest' user who has administrator access
+   - rabbitmq_user: user=guest
+                    state=absent
+
+   # Create a user who can write to the queues
+   - rabbitmq_user: user={{rabbitmq_write_user}}
+                    password={{rabbitmq_write_password}}
+                    force=yes
+                    vhost=/
+                    write_priv=.*
+                    configure_priv=.*
+                    read_priv=.*
+                    state=present
+
+   # Create a user who can read from queues
+   - rabbitmq_user: user={{rabbitmq_read_user}}
+                    password={{rabbitmq_read_password}}
+                    force=yes
+                    vhost=/
+                    read_priv=.*
+                    write_priv=.*
+                    configure_priv=.*
+                    state=present
+
+
+   # Create an admin user
+   - rabbitmq_user: user={{rabbitmq_admin_user}}
+                    password={{rabbitmq_admin_password}}
+                    force=yes
+                    vhost=/
+                    configure_priv=.*
+                    read_priv=.*
+                    write_priv=.*
+                    state=present
+                    tags=administrator


### PR DESCRIPTION
**_What**_
The goal of this story is to generate a cloud watch alarm when a RabbitMQ cluster partitions. To achieve this requires each Rabbit MQ instance to publish a Cloud watch metric regarding the status of it's cluster. This metric needs an alarm setup which notifies the Slack OPs channel if a cluster partition occurs. To achieve this requires a change in eq-message and eq-terraform.

The change in this PR sets up a cloud watch metric for rabbit mq cluster status and cron job to invoke it. The cloud watch alarm will be setup in the eq-terraform project. Link to follow.

**_How to test**_
See https://github.com/ONSdigital/eq-terraform/pull/43

**_Who can review**_
Anyone apart from @warrenbailey
