### PR TITLE
Moving to the mainline Rabbit MQ playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ EOF
 
 ```
 
-7. Install the warrenbailey.rabbitmq role from Ansible galaxy (this is where the magic happens)
+7. Install the alexeymedvedchikov.rabbitmq role from Ansible galaxy (this is where the magic happens)
 
 ```
-sudo ansible-galaxy install warrenbailey.rabbitmq
+sudo ansible-galaxy install alexeymedvedchikov.rabbitmq
 ```
 
 8. Run the rabbit mq playbook in this repository, this should provision the two EC2 instances, cluster them together and

--- a/ansible/rabbitmq-cluster.yml
+++ b/ansible/rabbitmq-cluster.yml
@@ -4,7 +4,7 @@
   sudo: yes
   user: ubuntu
   roles:
-    - warrenbailey.rabbitmq
+    - alexeymedvedchikov.rabbitmq
     - role: jnv.unattended-upgrades
       unattended_origins_patterns:
       - 'origin=Ubuntu,archive=${distro_codename}-security'
@@ -63,7 +63,7 @@
   sudo: yes
   user: ubuntu
   roles:
-    - warrenbailey.rabbitmq
+    - alexeymedvedchikov.rabbitmq
     - role: jnv.unattended-upgrades
       unattended_origins_patterns:
       - 'origin=Ubuntu,archive=${distro_codename}-security'

--- a/ansible/role.yml
+++ b/ansible/role.yml
@@ -3,7 +3,7 @@
 - hosts: all
   user: ubuntu
   roles:
-    - warrenbailey.rabbitmq
+    - alexeymedvedchikov.rabbitmq
     - role: jnv.unattended-upgrades
       unattended_origins_patterns:
       - 'origin=Ubuntu,archive=${distro_codename}-security'


### PR DESCRIPTION
The PR for the FQDN has been merged back into the main repository for this playbook, so we no longer need to use my forked version.

I suggest we delete the fork and use the main version going forward, which should mean we get regular updates

https://galaxy.ansible.com/warrenbailey/rabbitmq/
https://github.com/ONSDigital/ansible-rabbitmq

https://github.com/alexey-medvedchikov/ansible-rabbitmq
https://galaxy.ansible.com/alexeymedvedchikov/rabbitmq/
