### PR TITLE
Add ntp and Logging

### DIFF
--- a/ansible/tasks/cloudwatch.yml
+++ b/ansible/tasks/cloudwatch.yml
@@ -5,4 +5,4 @@
  - lineinfile: dest=/etc/environment line="METRIC_NAME={{host}}"
  - lineinfile: dest=/etc/environment line="NAMESPACE=RabbitMQClusterStatus"
  - lineinfile: dest=/etc/environment line="REGION={{region}}"
- - cron: name="Rabbit MQ Cluster check" minute="*/5" job="/opt/cluster_status.sh"
+ - cron: name="Rabbit MQ Cluster check" minute="*/5" job="/opt/cluster_status.sh >> /var/log/cluster_check.log 2>&1"

--- a/ansible/tasks/cloudwatch.yml
+++ b/ansible/tasks/cloudwatch.yml
@@ -1,4 +1,5 @@
 ---
+ - apt: name=ntp update_cache=yes
  - apt: name=awscli update_cache=yes
  - copy: src=tasks/cluster_status.sh dest=/opt/cluster_status.sh owner=ubuntu group=ubuntu mode=0754
  - lineinfile: dest=/etc/environment line="METRIC_NAME={{host}}"


### PR DESCRIPTION
Install `ntp` on the RabbitMQ servers so that the time stays in sync

The time becoming out of sync causes AWS CloudWatch metrics to fail to be reported as the signature generated in the request to AWS contains the time. If this time out outside of a set leeway then the request is rejected.

To deploy change the following line to.. https://github.com/ONSdigital/eq-terraform/blob/master/survey-runner-queue/message_queue.tf#L117
```
command = "git clone --single-branch -b add-ntp https://github.com/ONSdigital/eq-messaging.git tmp/eq-messaging"
```

To test this `ssh` into the box and run `ntpq -pn` if this command works then `ntp` is installed.